### PR TITLE
Add sassc binary to composer binaries list

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,12 @@
         "sass/libsass": "3.1.0",
         "sass/sassc": "3.1.0"
     },
+    "bin": [
+        "sassc"
+    ],
+    "config": {
+        "bin-dir": "bin"
+    },
     "extra": {
         "branch-alias": {
             "dev-master": "3.1-dev"


### PR DESCRIPTION
This makes it available in the consistent location of
vendor/bin/sassc, rather than having to dig into
vendor/lemonweb/sassc-binary/bin/sassc.
